### PR TITLE
Replace deprecated 'createEvent' and 'initMouseEvent' by 'new MouseEvent'

### DIFF
--- a/js/file-transfer.js
+++ b/js/file-transfer.js
@@ -150,8 +150,11 @@ var FileSaver = {
         save.target = '_blank';
         save.download = fileName || fileUrl;
 
-        var evt = document.createEvent('MouseEvents');
-        evt.initMouseEvent('click', true, true, window, 1, 0, 0, 0, 0, false, false, false, false, 0, null);
+        var evt = new MouseEvent('click', {
+            view: window,
+            bubbles: true,
+            cancelable: true
+        });
 
         save.dispatchEvent(evt);
 


### PR DESCRIPTION
'createEvent' is deprecated (see
https://developer.mozilla.org/en-US/docs/Web/API/document.createEvent),
so I implemented the same behavior by using 'new MouseEvent' (see
https://developer.mozilla.org/en-US/docs/Web/Guide/DOM/Events/Creating_and_triggering_events#Triggering_built-in_events)
