### PR TITLE
Change the demo link from HTTP to HTTPS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,6 @@ http://blog.printf.net/articles/2014/07/01/serverless-webrtc-continued
 
 #### Browser demo link:
 
-http://cjb.github.io/serverless-webrtc/serverless-webrtc.html
+https://cjb.github.io/serverless-webrtc/serverless-webrtc.html
 
 -- Chris Ball <chris@printf.net> (http://printf.net/)


### PR DESCRIPTION
Due to changes in the latest version of Chrome, some features such as getUserMedia no longer work on insecure sites

See https://sites.google.com/a/chromium.org/dev/Home/chromium-security/deprecating-powerful-features-on-insecure-origins for more info.

This PR changes the demo link to HTTPS, so everything works.